### PR TITLE
Fix compilation error in log_module.cpp on Ubuntu 24.04

### DIFF
--- a/ldlidar_driver/src/logger/log_module.cpp
+++ b/ldlidar_driver/src/logger/log_module.cpp
@@ -16,7 +16,7 @@
 * limitations under the License.
 **/
 #include "log_module.h"
-
+#include <pthread.h>
 #include <time.h>
 #include <string.h>
 


### PR DESCRIPTION
Compilation error on Ubuntu 24.04 and Debian 12:

error: ‘pthread_mutex_init’ was not declared in this scope; did you mean ‘pthread_mutex_t’?